### PR TITLE
Added support to react@15.0.0-rc.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-var shallowCompare = require('react-addons-shallow-compare');
+var shallowCompare = require('react/lib/shallowCompare');
 
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "felixgirault/pure-render-decorator",
   "main": "index.js",
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "dependencies": {
     "react-addons-shallow-compare": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-rc.1"
   },
-  "dependencies": {
-    "react-addons-shallow-compare": "^0.14.0"
-  },
   "devDependencies": {
     "mocha": "^2.3.3"
   },

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-var shallowCompare = require('react-addons-shallow-compare');
+var shallowCompare = require('react/lib/shallowCompare');
 var assert = require('assert');
 var decorate = require('./index');
 


### PR DESCRIPTION
Without an updated peer-dependency, npm shrinkwrap will fail on any project that uses react@15.0.0-rc.x and pure-render-decorator modules:

```
>  npm shrinkwrap
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: react@^0.14.0, required by pure-render-decorator@0.2.0
...
```
