### PR TITLE
Replace react-addons-shallow-compare with fbjs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,7 @@
  */
 'use strict';
 
-var shallowCompare = require('react-addons-shallow-compare');
-
-
+var shallowEqual = require('fbjs/lib/shallowEqual');
 
 /**
  * Tells if a component should update given it's next props
@@ -16,7 +14,7 @@ var shallowCompare = require('react-addons-shallow-compare');
  * @param object nextState Next state.
  */
 function shouldComponentUpdate(nextProps, nextState) {
-  return shallowCompare(this, nextProps, nextState);
+  return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^15.0.0 || ^0.14.0"
   },
   "dependencies": {
-    "fbjs": "^0.8.0"
+    "fbjs": "0.8.0"
   },
   "devDependencies": {
     "mocha": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^15.0.0 || ^0.14.0"
   },
   "dependencies": {
-    "react-addons-shallow-compare": "^15.0.0 || ^0.14.0"
+    "fbjs": "^0.8.0"
   },
   "devDependencies": {
     "mocha": "^2.3.3",

--- a/test.js
+++ b/test.js
@@ -4,11 +4,8 @@
  */
 'use strict';
 
-var shallowCompare = require('react-addons-shallow-compare');
 var assert = require('assert');
 var decorate = require('./index');
-
-
 
 /**
  *
@@ -21,32 +18,29 @@ describe('pure-render-decorator', function() {
   component.props = { foo: 1 };
   component.state = { bar: 2 };
 
-  /**
-   *
-   */
   it('should add a method named shouldComponentUpdate', function() {
     assert.ok('shouldComponentUpdate' in component);
     assert.ok(typeof component.shouldComponentUpdate === 'function');
   });
 
-  /**
-   *
-   */
-  it('should use shallowCompare to compare props and state', function() {
-    assert.equal(
-      component.shouldComponentUpdate({}, {}),
-      shallowCompare(component, {}, {})
-    );
+  it('should return true if the props and state are different', function() {
+    assert.ok(component.shouldComponentUpdate({}, {}));
+  });
 
-    assert.equal(
-      component.shouldComponentUpdate(
+  it('should return false if the props and state are reference-equals', function() {
+    assert.ok(
+      !component.shouldComponentUpdate(
         component.props,
         component.state
-      ),
-      shallowCompare(
-        component,
-        component.props,
-        component.state
+      )
+    );
+  });
+
+  it('should return false if props and state are shallow-equals but different references', function() {
+    assert.ok(
+      !component.shouldComponentUpdate(
+        { foo: 1 },
+        { bar: 2 }
       )
     );
   });


### PR DESCRIPTION
This library had a hard dependency on react-addons-shallow-compare, which as it turns out is a bad idea:
1. This library accepts React 15 and 14 (as it should; indeed, it could take many lower versions as well).
2. It depends on react-addons-shallow-compare, which has a peer dependency on React of the version matching its own.
3. npm will bias towards the higher version, so depending on react-addons-shallow-compare for either 14 or 15 means just 15. It's not a peer dependency, so npm has no obligation to do anything but exactly this.
4. If I consume this library from an application that uses React 14, npm will still install react-addons-shallow-compare 15, which has a peer dependency on React 15 (again, because we depend on it normally, not as a peer).
5. npm will yield a very confusing error message, claiming that I have a peer dependency on React 15, and React 14 doesn't qualify. As a bonus, it  won't tell me that the provenance of the conflicting requirement is this:
   (root) -> pure-render-decorator -> react-addons-shallow-compare -> react

So instead of dealing with all that, just implement React's shallowCompare with fbjs's shallowEqual, which is how it's done anyway. This line is copy- pasted straight from react-addons-shallow-compare. fbjs doesn't have any weird dependencies. It should be noted that fbjs says they will "do their best" to adhere to semver, but given the simplicity of this requirement, it should be just fine.

For more color, see:
- facebook/react#6498 (problems with peer dependencies)
- facebook/react#2909 (not shallow-compare, but a similar intent)
