### PR TITLE
Throw an error if user tries decorating a component that already implements shouldComponentUpdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ function shouldComponentUpdate(nextProps, nextState) {
  * @param object component Component.
  */
 function pureRenderDecorator(component) {
+  if (component.prototype.shouldComponentUpdate !== undefined) {
+    throw new Error("Cannot add a pure render decorator on a component that already"
+      + " implements shouldComponentUpdate, but " + component.prototype.name
+      + " already implements shouldComponentUpdate.")
+  }
   component.prototype.shouldComponentUpdate = shouldComponentUpdate;
   return component;
 }

--- a/index.js
+++ b/index.js
@@ -17,11 +17,20 @@ function shouldComponentUpdate(nextProps, nextState) {
   return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
 }
 
-function getFunctionName(fun) {
-  var ret = fun.toString();
-  ret = ret.substr('function '.length);
-  ret = ret.substr(0, ret.indexOf('('));
-  return ret;
+/**
+ * Get a text description of the component that can be used to identify it
+ * in error messages.
+ *
+ * Adapted from: https://github.com/facebook/react/blob/v15.4.0-rc.3/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L1143
+ * @return {string} The name or "a component".
+ */
+function getComponentName(component) {
+  var constructor = component.prototype && component.prototype.constructor;
+  return (
+    component.displayName || (constructor && constructor.displayName) ||
+    component.name || (constructor && constructor.name) ||
+    "a component"
+  );
 }
 
 /**
@@ -31,10 +40,9 @@ function getFunctionName(fun) {
  */
 function pureRenderDecorator(component) {
   if (component.prototype.shouldComponentUpdate !== undefined) {
-    var componentName = component.prototype.name || component.name || getFunctionName(component);
-    throw new Error("Cannot add a pure render decorator on a component that already"
-      + " implements shouldComponentUpdate, but " + componentName
-      + " already implements shouldComponentUpdate.")
+    var componentName = getComponentName(component);
+    throw new Error("Cannot add a pure render decorator to " + componentName
+      + ", because it already implements `shouldComponentUpdate()`.")
   }
   component.prototype.shouldComponentUpdate = shouldComponentUpdate;
   return component;

--- a/index.js
+++ b/index.js
@@ -17,6 +17,13 @@ function shouldComponentUpdate(nextProps, nextState) {
   return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState);
 }
 
+function getFunctionName(fun) {
+  var ret = fun.toString();
+  ret = ret.substr('function '.length);
+  ret = ret.substr(0, ret.indexOf('('));
+  return ret;
+}
+
 /**
  * Makes the given component "pure".
  *
@@ -24,8 +31,9 @@ function shouldComponentUpdate(nextProps, nextState) {
  */
 function pureRenderDecorator(component) {
   if (component.prototype.shouldComponentUpdate !== undefined) {
+    var componentName = component.prototype.name || component.name || getFunctionName(component);
     throw new Error("Cannot add a pure render decorator on a component that already"
-      + " implements shouldComponentUpdate, but " + component.prototype.name
+      + " implements shouldComponentUpdate, but " + componentName
       + " already implements shouldComponentUpdate.")
   }
   component.prototype.shouldComponentUpdate = shouldComponentUpdate;

--- a/test.js
+++ b/test.js
@@ -27,9 +27,9 @@ describe('pure-render-decorator', function() {
     function ComponentWithShouldComponentUpdate() {};
     ComponentWithShouldComponentUpdate.prototype.shouldComponentUpdate = () => false;
 
-    var expectedErrorMessage = "Cannot add a pure render decorator on a component"
-      + " that already implements shouldComponentUpdate, but ComponentWithShouldComponentUpdate"
-      + " already implements shouldComponentUpdate.";
+    var expectedErrorMessage = "Cannot add a pure render decorator to "
+      + "ComponentWithShouldComponentUpdate, because it already implements "
+      + "`shouldComponentUpdate\\(\\)`";
     assert.throws(() => decorate(ComponentWithShouldComponentUpdate), new RegExp(expectedErrorMessage));
   });
 

--- a/test.js
+++ b/test.js
@@ -23,6 +23,16 @@ describe('pure-render-decorator', function() {
     assert.ok(typeof component.shouldComponentUpdate === 'function');
   });
 
+  it('should throw an error if shouldComponentUpdate is already implemented', function() {
+    function ComponentWithShouldComponentUpdate() {};
+    ComponentWithShouldComponentUpdate.prototype.shouldComponentUpdate = () => false;
+
+    var expectedErrorMessage = "Cannot add a pure render decorator on a component"
+      + " that already implements shouldComponentUpdate, but ComponentWithShouldComponentUpdate"
+      + " already implements shouldComponentUpdate.";
+    assert.throws(() => decorate(ComponentWithShouldComponentUpdate), Error, expectedErrorMessage);
+  });
+
   it('should return true if the props and state are different', function() {
     assert.ok(component.shouldComponentUpdate({}, {}));
   });

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ describe('pure-render-decorator', function() {
     var expectedErrorMessage = "Cannot add a pure render decorator on a component"
       + " that already implements shouldComponentUpdate, but ComponentWithShouldComponentUpdate"
       + " already implements shouldComponentUpdate.";
-    assert.throws(() => decorate(ComponentWithShouldComponentUpdate), Error, expectedErrorMessage);
+    assert.throws(() => decorate(ComponentWithShouldComponentUpdate), new RegExp(expectedErrorMessage));
   });
 
   it('should return true if the props and state are different', function() {


### PR DESCRIPTION
Currently if you do this:

```
@pureRender
class MyComponent {
    public shouldComponentUpdate() {
        return doSomething();
    }
}
```

Then it won't warn you, and will just ignore the shouldComponentUpdate method. I've seen this confuse a number of devs -- and they can get stuck on the problem for quite a while. Since there's never a valid reason to add a shouldComponentUpdate and decorate your class it should throw a warning.

This PR would make the above code throw an error of the format:

  `Cannot add a pure render decorator on a component that already implements shouldComponentUpdate, but MyComponent already implements shouldComponentUpdate.`
